### PR TITLE
feat(shell-settings): add zshrc settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ macOSで使える便利なスクリプト集
 | Script Name | Description |
 | --- | --- |
 | [daily-dict-updater](./daily-dict-updater/README.md) | 「[Google日本語入力](https://www.google.co.jp/ime/)」の辞書を日次で更新するためのツール。 |
+| [shell-settings](./shell-settings/README.md) | zshrcなどの設定群 |
 | [vscode-settings](./vscode-settings/README.md) | Visual Studio Codeの設定ファイルを管理するためのツール。 |

--- a/shell-settings/.zshrc
+++ b/shell-settings/.zshrc
@@ -1,0 +1,12 @@
+# PS1: prompt string
+# %DT%*: date and time
+# %1~: current directory (shortened)
+# %#: prompt symbol
+export PS1="%DT%* %1~ %# "
+
+# prevent overwriting files
+set -o noclobber
+
+# (optional) exec shell script when terminal is opened
+# script path is just an example
+sh ~/daily-dict-updater/wakeup.shell

--- a/shell-settings/README.md
+++ b/shell-settings/README.md
@@ -1,0 +1,5 @@
+# shell-settings
+
+## How to use
+
+- zshの場合: `~/.zshrc`


### PR DESCRIPTION
# 関連URL
- なし

# 概要
- `.zshrc` の設定を書き出した
- sleepwatherをトリガーにしていた `daily-dict-updater` を、zsh立ち上げをトリガーにするようにした
  - （もちろん、sleepwatherをトリガーにする方法も引き続き可能）

# 動作確認
- zshrcに内容反映して確認済み

# レビュー観点
- なし

# TODO
- なし
